### PR TITLE
support other arduino-compatible platforms

### DIFF
--- a/Arduino/hx1230.cpp
+++ b/Arduino/hx1230.cpp
@@ -1,5 +1,11 @@
 #include <Arduino.h>
-#include <avr/pgmspace.h>
+
+#if (defined(__AVR__))
+#include <avr\pgmspace.h>
+#else
+#include <pgmspace.h>
+#endif
+
 #include <hx1230.h>
 //
 // HX1230 LCD Library


### PR DESCRIPTION
avr/pgmspace.h is specific to avr, does not exist on ESP32, ESP8266, etc.  Use pgmspace.h if not AVR.